### PR TITLE
Sudoers feature in capistrano deployment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -3,6 +3,7 @@ require "capistrano/setup"
 
 # Include default deployment tasks
 require "capistrano/deploy"
+require "sshkit/sudo"
 
 require "capistrano/scm/git"
 install_plugin Capistrano::SCM::Git

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -28,8 +28,6 @@ group :production, :staging do
   gem "unicorn"
   gem "unicorn-worker-killer"
 <% end -%>
-  gem "sshkit", ">= 1.16", require: false
-  gem "sshkit-sudo", ">= 0.1"
 end
 
 group :development do
@@ -63,6 +61,7 @@ group :development do
   gem "simplecov", require: false
   gem "spring"
   gem "sshkit", "~> 1.16", require: false
+  gem "sshkit-sudo", ">= 0.1"
 <% if gemfile_requirement("spring-watcher-listen") -%>
   gem "spring-watcher-listen"<%= gemfile_requirement("spring-watcher-listen") %>
 <% end -%>

--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -28,6 +28,8 @@ group :production, :staging do
   gem "unicorn"
   gem "unicorn-worker-killer"
 <% end -%>
+  gem "sshkit", ">= 1.16", require: false
+  gem "sshkit-sudo", ">= 0.1"
 end
 
 group :development do


### PR DESCRIPTION
Add new feature for deployment with Capistrano.
- Require `sshkit/sudo` in `Capfile`
- Add new gems `sshkit-sudo` in development group