### PR TITLE
Improve Docker support by changing HOSTNAME var

### DIFF
--- a/README.md.tt
+++ b/README.md.tt
@@ -52,8 +52,8 @@ Ensure the following environment variables are set in the deployment environment
 
 Optionally:
 
-* `HOSTNAME`
 * `RAILS_FORCE_SSL`
+* `RAILS_HOSTNAME`
 * `RAILS_LOG_TO_STDOUT`
 * `RAILS_MAX_THREADS`
 * `RAILS_SERVE_STATIC_FILES`

--- a/config.ru.rb
+++ b/config.ru.rb
@@ -1,5 +1,5 @@
 insert_into_file "config.ru", before: /^run Rails.application/ do
   <<-RUBY
-use Rack::CanonicalHost, ENV["HOSTNAME"] if ENV["HOSTNAME"].present?
+use Rack::CanonicalHost, ENV["RAILS_HOSTNAME"] if ENV["RAILS_HOSTNAME"].present?
   RUBY
 end


### PR DESCRIPTION
Docker containers set a HOSTNAME var by default which is not what our `config.ru` is expecting. To avoid this conflict, change the name of the variable we expect to RAILS_HOSTNAME. This allows a Docker container to run the Rails app out of the box.

Fixes #21