### PR TITLE
Add yarn requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This template currently works with:
 * Bundler 2.x
 * PostgreSQL
 
+*When using the optional support for Vite:*
+* Node 16.*
+* Yarn 1.x (if using the optional support for Vite)
+
 If you need help setting up a Ruby development environment, check out my [Rails OS X Setup Guide](https://mattbrictson.com/rails-osx-setup-guide).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This template currently works with:
 * Bundler 2.x
 * PostgreSQL
 
-*When using the optional support for Vite:*
-* Node 16.*
-* Yarn 1.x (if using the optional support for Vite)
+*When using `--javascript vite`:*
+* Node 16.x
+* Yarn 1.x
 
 If you need help setting up a Ruby development environment, check out my [Rails OS X Setup Guide](https://mattbrictson.com/rails-osx-setup-guide).
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This template currently works with:
 * PostgreSQL
 
 *When using `--javascript vite`:*
-* Node 16.x
+* Node 16 or later
 * Yarn 1.x
 
 If you need help setting up a Ruby development environment, check out my [Rails OS X Setup Guide](https://mattbrictson.com/rails-osx-setup-guide).


### PR DESCRIPTION
Hi Matt 👋 Thanks for maintaining this template!

### Problem

I was using the template with `--javascript vite`, and got through most of the install, but it failed at the `yarn add` step. This is because I currently do not have Yarn installed on my machine.

### Proposed solution

I'm not sure if it's adding too much to the front of the README, but it may be worth calling out Yarn as a dependency. 

That said, it's pretty obvious what's going wrong when it fails at that step, and maybe most devs have Yarn installed anyway. So I could see an argument for leaving it out to keep the README simple.