### PR TITLE
Remove Pico.css; recommend modern-normalize plus small reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ If you don't specify `--javascript vite`, then this template will use the standa
     * [sidekiq][] – Redis-based job queue implementation for Active Job
 * Configuration
     * [dotenv][] – for local configuration
-* Style
-    * [Pico.css][pico] - a great-looking default stylesheet
 * Utilities
     * [annotate][] – auto-generates schema documentation
     * [good_migrations][] - prevents app models from being improperly referenced in migrations
@@ -131,7 +129,6 @@ Rails generators are very lightly documented; what you’ll find is that most of
 [rubocop]:https://github.com/bbatsov/rubocop
 [erblint]:https://github.com/Shopify/erb-lint
 [factory_bot_rails]:https://github.com/thoughtbot/factory_bot_rails
-[pico]:https://picocss.com
 [Postmark]:http://postmarkapp.com
 [postmark-rails]:http://www.rubydoc.info/gems/postmark-rails/0.12.0
 [brakeman]:https://github.com/presidentbeef/brakeman

--- a/app/frontend/stylesheets/base.css
+++ b/app/frontend/stylesheets/base.css
@@ -1,0 +1,8 @@
+/*
+  This file is for base element styles, like:
+
+  - Any @font-face declarations needed custom web fonts.
+  - Default font-family on the body element.
+  - Default foreground, background, and link colors.
+  - Global CSS variables (declared on :root), such as color palette.
+*/

--- a/app/frontend/stylesheets/index.css
+++ b/app/frontend/stylesheets/index.css
@@ -1,0 +1,3 @@
+@import "modern-normalize";
+@import "reset";
+@import "base";

--- a/app/frontend/stylesheets/index.scss
+++ b/app/frontend/stylesheets/index.scss
@@ -1,6 +1,0 @@
-@import "@picocss/pico";
-
-// Uncomment this to disable Pico's responsive sizing and instead respect the user's browser font size setting
-// :root {
-//   --font-size: revert;
-// }

--- a/app/frontend/stylesheets/reset.css
+++ b/app/frontend/stylesheets/reset.css
@@ -1,0 +1,36 @@
+:root {
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+figure,
+p,
+ol,
+ul {
+  margin: 0;
+}
+
+ol,
+ul {
+  list-style: none;
+  padding-inline: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+img {
+  display: block;
+  max-inline-size: 100%;
+}

--- a/app/frontend/template.rb
+++ b/app/frontend/template.rb
@@ -1,7 +1,9 @@
 empty_directory_with_keep_file "app/frontend/fonts"
 empty_directory_with_keep_file "app/frontend/images"
 
-copy_file "app/frontend/stylesheets/index.scss"
+copy_file "app/frontend/stylesheets/index.css"
+copy_file "app/frontend/stylesheets/base.css"
+copy_file "app/frontend/stylesheets/reset.css"
 
 copy_file "app/frontend/images/example.svg"
 copy_file "app/lib/vite_inline_svg_file_loader.rb"
@@ -17,7 +19,7 @@ end
 if package_json.match?(%r{@hotwired/stimulus})
   prepend_to_file "app/frontend/entrypoints/application.js", <<~JS
     import "~/controllers";
-    import "~/stylesheets/index.scss";
+    import "~/stylesheets/index.css";
   JS
 end
 

--- a/app/template.rb
+++ b/app/template.rb
@@ -40,10 +40,6 @@ if install_vite?
   gsub_file "app/views/layouts/base.html.erb",
             /vite_javascript_tag 'application' %>/,
             'vite_javascript_tag "application", "data-turbo-track": "reload" %>'
-else
-  insert_into_file "app/views/layouts/base.html.erb", <<-ERB, before: /^.*<%= stylesheet_link_tag.*$/
-    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
-  ERB
 end
 
 copy_file "app/views/layouts/application.html.erb"

--- a/template.rb
+++ b/template.rb
@@ -59,7 +59,7 @@ def apply_template!
       File.rename("app/javascript", "app/frontend") if File.exist?("app/javascript")
       run_with_clean_bundler_env "bundle exec vite install"
       run "yarn remove vite-plugin-ruby"
-      run "yarn add autoprefixer postcss rollup sass vite-plugin-rails @picocss/pico"
+      run "yarn add autoprefixer postcss rollup vite-plugin-rails modern-normalize"
       copy_file "postcss.config.js"
       copy_file "vite.config.ts", force: true
       apply "app/frontend/template.rb"


### PR DESCRIPTION
Pico.css is great as a zero-styles solution, but most apps are going to need their own styles. In the case where Pico.css is enough, it is easy to add manually.

Instead, advocate for a normalize+reset starting point for writing CSS.

When using Vite, go with plain CSS instead of SCSS.