### PR TITLE
Remove eslint-plugin-prettier alpha pin

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -249,7 +249,7 @@ def add_yarn_lint_and_run_fix
   packages = %w[
     eslint
     eslint-config-prettier
-    eslint-plugin-prettier@^5.0.0-alpha.2
+    eslint-plugin-prettier
     postcss
     prettier
     stale-dep


### PR DESCRIPTION
The final version of eslint-plugin-prettier 5.0.0 has been released, adding compatibility with Prettier 3.0. This means that pinning to the alpha version is no longer necessary.

https://github.com/prettier/eslint-plugin-prettier/releases/tag/v5.0.0