### PR TITLE
Simplify default rake task

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -2,21 +2,15 @@ append_to_file "Rakefile" do
   <<~RUBY
 
   Rake::Task[:default].prerequisites.clear if Rake::Task.task_defined?(:default)
-  task :default do
-    sh "bin/rails test"
-    sh "bin/rails test:system"
 
-    raise unless
-      system("bin/rubocop") &
-      system("bin/erblint --lint-all") &
-      system("yarn lint")
+  desc "Run all checks"
+  task default: %w[test:all rubocop erblint yarn:lint] do
+    Thor::Base.shell.new.say_status :OK, "All checks passed!"
   end
 
-  task :fix do
-    raise unless
-      system("bin/rubocop -a") &
-      system("bin/erblint --lint-all -a") &
-      system("yarn fix")
+  desc "Apply auto-corrections"
+  task fix: %w[rubocop:autocorrect_all erblint:autocorrect yarn:fix] do
+    Thor::Base.shell.new.say_status :OK, "All fixes applied!"
   end
   RUBY
 end

--- a/lib/tasks/erblint.rake
+++ b/lib/tasks/erblint.rake
@@ -1,0 +1,11 @@
+desc "Run erblint"
+task :erblint do
+  sh "bin/erblint --lint-all"
+end
+
+namespace :erblint do
+  desc "Autocorrect erblint offenses"
+  task :autocorrect do
+    sh "bin/erblint --lint-all -a"
+  end
+end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,4 @@
+return unless Gem.loaded_specs.key?("rubocop")
+
+require "rubocop/rake_task"
+RuboCop::RakeTask.new

--- a/lib/tasks/yarn.rake
+++ b/lib/tasks/yarn.rake
@@ -1,0 +1,11 @@
+namespace :yarn do
+  desc "Run yarn lint script"
+  task :lint do
+    sh "yarn lint"
+  end
+
+  desc "Run yarn fix script"
+  task :fix do
+    sh "yarn fix"
+  end
+end

--- a/lib/template.rb
+++ b/lib/template.rb
@@ -1,2 +1,5 @@
 copy_file "lib/puma/plugin/open.rb"
 copy_file "lib/tasks/auto_annotate_models.rake"
+copy_file "lib/tasks/erblint.rake"
+copy_file "lib/tasks/rubocop.rake"
+copy_file "lib/tasks/yarn.rake"

--- a/template.rb
+++ b/template.rb
@@ -266,6 +266,7 @@ def add_yarn_lint_and_run_fix
     eslint
     eslint-config-prettier
     eslint-plugin-prettier
+    npm-run-all
     postcss
     prettier
     stale-dep
@@ -274,8 +275,10 @@ def add_yarn_lint_and_run_fix
     stylelint-declaration-strict-value
     stylelint-prettier
   ]
-  add_package_json_script("fix": "npm run -- lint:js --fix && npm run -- lint:css --fix")
-  add_package_json_script("lint": "npm run lint:js && npm run lint:css")
+  add_package_json_script("fix": "npm-run-all fix:**")
+  add_package_json_script("fix:js": "npm run -- lint:js --fix")
+  add_package_json_script("fix:css": "npm run -- lint:css --fix")
+  add_package_json_script("lint": "npm-run-all lint:**")
   add_package_json_script("lint:js": "stale-dep && eslint 'app/{components,frontend,javascript}/**/*.{js,jsx}'")
   add_package_json_script("lint:css": "stale-dep && stylelint 'app/{components,frontend,assets/stylesheets}/**/*.css'")
   add_package_json_script("postinstall": "stale-dep -u")


### PR DESCRIPTION
By specifying the default task as a list of prerequisites, this allows the multitask (`-m`) option to be used to speed things up.

Also adds `npm-run-all` as a simpler way to run the yarn lint and fix scripts.